### PR TITLE
fix: use before_action instead of before_filter clauses

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -2,7 +2,7 @@ module Spree
   Spree::CheckoutController.class_eval do
     #autoload :Helper, 'active_merchant/billing/integrations/redsys/helper.rb'
 
-    before_filter :redirect_to_redsys_form_if_needed, :only => [:update]
+    before_action :redirect_to_redsys_form_if_needed, :only => [:update]
 
     protected
 

--- a/app/controllers/spree/redsys_callbacks_controller.rb
+++ b/app/controllers/spree/redsys_callbacks_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   class RedsysCallbacksController < Spree::BaseController
 
-    skip_before_filter :verify_authenticity_token
+    skip_before_action :verify_authenticity_token
 
     #ssl_required
 


### PR DESCRIPTION
## Reference
This comes from the error: undefined method `before_filter' for Spree::CheckoutController:Class (NoMethodError) in both files

## Notes
I hope you guys don't mind me fixing this.
